### PR TITLE
refs #68775: upgrading android and sdk versions.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -255,6 +255,8 @@ android {
 }
 
 dependencies {
+    implementation 'org.jetbrains:annotations:16.0.2'
+
     implementation("com.mapbox.maps:android:10.1.16")
 
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/android/app/src/main/java/com/yukon/MainApplication.java
+++ b/android/app/src/main/java/com/yukon/MainApplication.java
@@ -12,6 +12,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import com.facebook.react.bridge.JSIModulePackage;
 import com.swmansion.reanimated.ReanimatedJSIModulePackage;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import org.jetbrains.annotations.Nullable;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -45,7 +50,14 @@ public class MainApplication extends Application implements ReactApplication {
   public ReactNativeHost getReactNativeHost() {
     return mReactNativeHost;
   }
-
+  @Override
+  public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter) {
+    if (Build.VERSION.SDK_INT >= 34 && getApplicationInfo().targetSdkVersion >= 34) {
+      return super.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+    } else {
+      return super.registerReceiver(receiver, filter);
+    }
+  }
   @Override
   public void onCreate() {
     super.onCreate();

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,10 +4,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "32.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-root-siblings": "^4.1.0",
     "react-native-root-toast": "^3.3.0",
     "react-native-safe-area-context": "^4.1.2",
-    "react-native-screens": "3.19.0",
+    "react-native-screens": "3.22.1",
     "react-native-snap-carousel": "gimi-org/react-native-snap-carousel.git#73db7cb",
     "react-native-svg": "^12.3.0",
     "react-native-swipe-gestures": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,10 +7817,10 @@ react-native-safe-area-view@^0.14.9:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-screens@3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.19.0.tgz#ec68685e04b074ebce4641b3a0ae7e2571629b75"
-  integrity sha512-Ehsmy7jr3H3j5pmN+/FqsAaIAD+k+xkcdePfLcg4rYRbN5X7fJPgaqhcmiCcZ0YxsU8ttsstP9IvRLNQuIkRRA==
+react-native-screens@3.22.1:
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.22.1.tgz#b0eb0696dbf1f9a852061cc71c0f8cdb95ed8e53"
+  integrity sha512-ffzwUdVKf+iLqhWSzN5DXBm0s2w5sN0P+TaHHPAx42LT7+DT0g8PkHT1QDvxpR5vCEPSS1i3EswyVK4HCuhTYg==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
## Ticket:

- https://rm.ewdev.ca/issues/68775

## Tasks completed:

- Updated API SDK version to 34.
- Updated Gradle version to support the new API version.
- Added support to registerReceiver function for API 34.
- Updated `react-native-screens` version in order to fix the error: `Type mismatch: inferred type is Canvas? but Canvas was expected
`.