### PR TITLE
refs #69767: site type app crash fix

### DIFF
--- a/src/components/screenParallaxWrapper/index.js
+++ b/src/components/screenParallaxWrapper/index.js
@@ -54,49 +54,51 @@ const ScreenParallaxWrapper = props => {
       stickyHeaderHeight={search ? 120 : 0}
       renderBackground={() => {
         return (
-          <View>
-            {typeof backgroundImage === 'string' ? (
+          backgroundImage ? (
+            <View>
+              {typeof backgroundImage === 'string' ? (
+                <Image
+                  source={{uri: backgroundImage}}
+                  style={{
+                    width: windowWidth,
+                    height: headerHeight,
+                    paddingBottom: 100,
+                  }}
+                />
+              ) : (
+                // <ImageCache
+                //   tint={'light'}
+                //   transitionDuration={300}
+                //   resizeMode="cover"
+                //   // fallback={fallback}
+                //   uri={backgroundImage}
+                //   style={{
+                //     width: windowWidth,
+                //     height: headerHeight,
+                //     paddingBottom: 100,
+                //   }}
+                // />
+                <Image
+                  style={{
+                    width: windowWidth,
+                    height: headerHeight,
+                    paddingBottom: 100,
+                  }}
+                  source={backgroundImage}
+                />
+              )}
               <Image
-                source={{uri: backgroundImage}}
+                source={overlay}
                 style={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
                   width: windowWidth,
-                  height: headerHeight,
-                  paddingBottom: 100,
+                  resizeMode: 'cover',
                 }}
               />
-            ) : (
-              // <ImageCache
-              //   tint={'light'}
-              //   transitionDuration={300}
-              //   resizeMode="cover"
-              //   // fallback={fallback}
-              //   uri={backgroundImage}
-              //   style={{
-              //     width: windowWidth,
-              //     height: headerHeight,
-              //     paddingBottom: 100,
-              //   }}
-              // />
-              <Image
-                style={{
-                  width: windowWidth,
-                  height: headerHeight,
-                  paddingBottom: 100,
-                }}
-                source={backgroundImage}
-              />
-            )}
-            <Image
-              source={overlay}
-              style={{
-                position: 'absolute',
-                bottom: 0,
-                left: 0,
-                width: windowWidth,
-                resizeMode: 'cover',
-              }}
-            />
-          </View>
+            </View>
+          ) : null
         );
       }}
       renderForeground={() => (
@@ -156,8 +158,7 @@ const ScreenParallaxWrapper = props => {
 };
 
 ScreenParallaxWrapper.propTypes = {
-  backgroundImage: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-    .isRequired,
+  backgroundImage: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   leadIcon: PropTypes.node,
   leadIconStyle: PropTypes.object,
   title: PropTypes.string.isRequired,

--- a/src/screens/siteDetails/index.js
+++ b/src/screens/siteDetails/index.js
@@ -250,11 +250,11 @@ const SiteDetailsScreen = props => {
         }}
       />
 
-      <Section title={t('siteDetails.siteTypes.title')}>
-        <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
-          {site_types &&
-            site_types.length &&
-            site_types.map((item, i) => {
+      {site_types &&
+      site_types.length ? (
+        <Section title={t('siteDetails.siteTypes.title')}>
+          <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
+            {site_types.map((item, i) => {
               return (
                 <SiteType
                   key={i}
@@ -264,10 +264,11 @@ const SiteDetailsScreen = props => {
                 />
               );
             })}
-        </View>
-      </Section>
+          </View>
+        </Section>
+      ) : null}
 
-      {!_isEmpty(warning) && (
+      {!_isEmpty(warning) ? (
         <Section
           title={t('siteDetails.sectionInfo.title')}
           backgroundColor={'#fdf6e9'}
@@ -279,7 +280,7 @@ const SiteDetailsScreen = props => {
             {warning}
           </Body>
         </Section>
-      )}
+      ) : null}
 
       <Section title={t('siteDetails.sectionDescription.title')}>
         <Body black>{site_description.replace(/&nbsp;/g, ' ')}</Body>


### PR DESCRIPTION
## Ticket:

- https://rm.ewdev.ca/issues/69767

## Tasks completed:

- Fixing `site_types && site_types.length` condition so now if it is false it doesn't return a string "false", it returns null instead.
- Changing `<ScreenParallaxWrapper>` logic so it works correctly when it doesn't recieves the `backgroundImage` prop.

## Steps to test.

1. Start the app in french.
2. Scroll down until you find a post with no image with the title: "Welcome to the Yukon sign - Alaska Highway East".
3. Click on it, now it should work as expected.